### PR TITLE
Rename Send Scopes

### DIFF
--- a/src/Models/Send.php
+++ b/src/Models/Send.php
@@ -29,6 +29,8 @@ use Wnx\Sends\Database\Factories\SendFactory;
  * @property ?Carbon $bounced_at
  * @property ?Carbon $permanent_bounced_at
  * @property ?Carbon $rejected_at
+ * @method static Builder forMessageId(string $messageId)
+ * @method static Builder forMailClass(string $mailClass)
  */
 class Send extends Model
 {

--- a/src/Models/Send.php
+++ b/src/Models/Send.php
@@ -79,12 +79,12 @@ class Send extends Model
         return new SendFactory();
     }
 
-    public function scopeByMessageId(Builder $builder, string $messageId): void
+    public function scopeForMessageId(Builder $builder, string $messageId): void
     {
         $builder->where('message_id', $messageId);
     }
 
-    public function scopeByMailClass(Builder $builder, string $mailClass): void
+    public function scopeForMailClass(Builder $builder, string $mailClass): void
     {
         $builder->where('mail_class', $mailClass);
     }

--- a/tests/Listeners/StoreOutgoingMailListenerTest.php
+++ b/tests/Listeners/StoreOutgoingMailListenerTest.php
@@ -70,8 +70,8 @@ it('stores to cc and bcc addresses in database table', function () {
     ]);
 });
 
-it('stores transport message id in database table', function () {
-    $this->addTransportMessageIdHeaderToMail();
+it('stores message id in database table', function () {
+    $this->addMessageIdHeaderToMail();
 
     Mail::to('test@example.com')
         ->send(new TestMail());

--- a/tests/Models/SendTest.php
+++ b/tests/Models/SendTest.php
@@ -6,13 +6,13 @@ use function PHPUnit\Framework\assertTrue;
 use Wnx\Sends\Models\Send;
 use Wnx\Sends\Tests\TestSupport\Mails\TestMailWithMailClassHeader;
 
-it('finds send model by given transport message id', function () {
+it('finds send model by given message id', function () {
 
     /** @var Send $send */
     $send = Send::factory()->create();
 
     /** @var Send $result */
-    $result = Send::byMessageId($send->message_id)->first();
+    $result = Send::forMessageId($send->message_id)->first();
 
     assertTrue($result->is($send));
 });
@@ -24,7 +24,7 @@ it('finds send model by given model class fqn', function () {
     ]);
 
     /** @var Send $result */
-    $result = Send::byMailClass($send->mail_class)->first();
+    $result = Send::forMailClass($send->mail_class)->first();
 
     assertTrue($result->is($send));
 });

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -57,7 +57,7 @@ class TestCase extends Orchestra
         });
     }
 
-    public function addTransportMessageIdHeaderToMail(): void
+    public function addMessageIdHeaderToMail(): void
     {
         Event::listen(MessageSending::class, [AttachCustomMessageIdListener::class, 'handle']);
     }


### PR DESCRIPTION
Rename the model scopes on the `Send`-model:

- `byMessageId()` → `forMessageId()`
- `byMailClass()` → `forMailclass()`