### PR TITLE
Update associateWith signature to either pass an array or multiple HasSends models as arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ protected $listen = [
 ]
 ```
 
-The metadata of **all** outgoing emails created by mailables or notifications is now being stored in the `sends`-table. (Note that you currently can only associate models to mailables but not to notifiations)
+The metadata of **all** outgoing emails created by mailables or notifications is now being stored in the `sends`-table. (Note that you can only associate models to mailables; but not to notifiations)
 
 Read further to learn how to store the name and how to associate models with a Mailable class.
 
@@ -146,7 +146,7 @@ class ProductReviewMail extends Mailable
 }
 ```
 
-The method will add a `X-Laravel-Mail-Class`-header to the outgoing email containing the fully qualified name (FQN) of the Mailable class as an encrypted string. (eg. `App\Mails\ProductReviewMail`)
+The method will add a `X-Laravel-Mail-Class`-header to the outgoing email containing the fully qualified name (FQN) of the Mailable class as an encrypted string. (eg. `App\Mails\ProductReviewMail`). Update the `SENDS_HEADERS_MAIL_CLASS`-env variable to adjust the header name. (See config for details).
 
 The package's event listener will then look for the header, decrypt the value and store it in the database.
 
@@ -167,7 +167,7 @@ class Product extends Model implements HasSends
 }
 ```
 
-You can now call the `associateWith()`-method within the `build()`-method and pass it an array of Models you want to associate with the Mailable class.
+You can now call the `associateWith()`-method within the `build()`-method. Pass the Models you want to associate with the Mailable class to the method as arguments. Instead of passing the Models as arguments, you can also pass them as an array.
 
 ```php
 class ProductReviewMail extends Mailable
@@ -183,7 +183,8 @@ class ProductReviewMail extends Mailable
     {
         return $this
             ->storeClassName()
-            ->associateWith([$this->product])
+            ->associateWith($this->product)
+            // ->associateWith([$this->product])
             ->view('emails.products.review')
             ->subject("$this->user->name, $this->product->name waits for your review");
     }
@@ -227,7 +228,7 @@ class ProductReviewMail extends Mailable
 If you're sending emails through AWS SES or a similar service, you might want to identify the sent email in the future (for example when a webhook for the "Delivered"-event is sent to your application).
 
 The package comes with an event listener helping you here. Update the EventServiceProvider to listen to the `MessageSending` event and add the `AttachCustomMessageIdListener` as a listener. 
-A `X-Laravel-Message-ID` will be attached to all outgoing emails.
+A `X-Laravel-Message-ID` header will be attached to all outgoing emails. The header contains a UUID value. This value is can not be compared to the `Message-ID` defined in [RFC 2392](https://datatracker.ietf.org/doc/html/rfc2392).
 
 ```php
 // app/Providers/EventServiceProvider.php

--- a/src/Support/StoreMailables.php
+++ b/src/Support/StoreMailables.php
@@ -22,7 +22,7 @@ trait StoreMailables
     }
 
     /**
-     * @param array<HasSends> $models
+     * @param array<HasSends>|HasSends $models
      * @return StoreMailables
      * @throws \ReflectionException
      */

--- a/src/Support/StoreMailables.php
+++ b/src/Support/StoreMailables.php
@@ -26,8 +26,10 @@ trait StoreMailables
      * @return StoreMailables
      * @throws \ReflectionException
      */
-    protected function associateWith(array $models = []): static
+    protected function associateWith(array|HasSends $models = []): static
     {
+        $models = $models instanceof HasSends ? func_get_args() : $models;
+
         $models = collect($models)
             ->when(count($models) === 0, function (Collection $collection) {
                 $publicPropertyWithHasSends = collect((new ReflectionClass($this))

--- a/tests/Listeners/StoreOutgoingMailListenerTest.php
+++ b/tests/Listeners/StoreOutgoingMailListenerTest.php
@@ -12,7 +12,9 @@ use Wnx\Sends\Tests\TestSupport\Mails\TestMailWithMailClassHeader;
 use Wnx\Sends\Tests\TestSupport\Mails\TestMailWithPublicProperties;
 use Wnx\Sends\Tests\TestSupport\Mails\TestMailWithRelatedModelsHeader;
 use Wnx\Sends\Tests\TestSupport\Mails\TestMailWithRelatedModelsHeaderAndPublicProperties;
+use Wnx\Sends\Tests\TestSupport\Mails\TestMailWithRelatedModelsHeaderPassAsArguments;
 use Wnx\Sends\Tests\TestSupport\Mails\TestMailWithRelatedModelsHeaderWrongModel;
+use Wnx\Sends\Tests\TestSupport\Models\AnotherTestModel;
 use Wnx\Sends\Tests\TestSupport\Models\TestModel;
 use Wnx\Sends\Tests\TestSupport\Models\TestModelWithoutHasSendsContract;
 use Wnx\Sends\Tests\TestSupport\Notifications\TestNotification;
@@ -115,6 +117,33 @@ it('attaches related models to a send model if respective header is present', fu
         'send_id' => 1,
         'sendable_type' => TestModel::class,
         'sendable_id' => 1,
+    ]);
+});
+
+it('attaches related models to a send model by passing arguments to associateWith method', function () {
+    $testModel = TestModel::create();
+    $anotherTestModel = AnotherTestModel::create();
+
+    Mail::to('test@example.com')
+        ->send(new TestMailWithRelatedModelsHeaderPassAsArguments($testModel, $anotherTestModel));
+
+    assertDatabaseHas('sends', [
+        'mail_class' => null,
+        'subject' => '::subject::',
+        'to' => json_encode(['test@example.com' => null]),
+        'cc' => null,
+        'bcc' => null,
+        ['sent_at', '!=', null],
+    ]);
+    assertDatabaseHas('sendables', [
+        'send_id' => 1,
+        'sendable_type' => TestModel::class,
+        'sendable_id' => 1,
+    ]);
+    assertDatabaseHas('sendables', [
+        'send_id' => 1,
+        'sendable_type' => AnotherTestModel::class,
+        'sendable_id' => 2,
     ]);
 });
 

--- a/tests/TestSupport/Mails/TestMailWithRelatedModelsHeaderPassAsArguments.php
+++ b/tests/TestSupport/Mails/TestMailWithRelatedModelsHeaderPassAsArguments.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Wnx\Sends\Tests\TestSupport\Mails;
+
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+use Wnx\Sends\Support\StoreMailables;
+use Wnx\Sends\Tests\TestSupport\Models\AnotherTestModel;
+use Wnx\Sends\Tests\TestSupport\Models\TestModel;
+
+class TestMailWithRelatedModelsHeaderPassAsArguments extends Mailable
+{
+    use StoreMailables;
+    use SerializesModels;
+
+    public function __construct(private TestModel $testModel, private AnotherTestModel $anotherTestModel)
+    {
+    }
+
+    public function build()
+    {
+        return $this
+            ->associateWith($this->testModel, $this->anotherTestModel)
+            ->view('emails.test')
+            ->subject("::subject::");
+    }
+}

--- a/tests/TestSupport/Models/AnotherTestModel.php
+++ b/tests/TestSupport/Models/AnotherTestModel.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Wnx\Sends\Tests\TestSupport\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Wnx\Sends\Contracts\HasSends;
+use Wnx\Sends\Support\HasSendsTrait;
+
+class AnotherTestModel extends Model implements HasSends
+{
+    use HasSendsTrait;
+
+    protected $table = 'test_models';
+}


### PR DESCRIPTION
This PR updates the signature of the `associateWith()`-method, so that either an array or multiple `HasSends`-models can be passed as the argument to the method.

This change mimick the behavior often seen in the Laravel framework, where either an array or a list can be passed to a method. The list of arguments is internally transformed into an array.

## TODO

- [x] Update README/docs
