### PR TITLE
Store Content of outgoing mail messages in the database

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,11 @@ return [
      */
     'send_model' => \Wnx\Sends\Models\Send::class,
 
+    /**
+     * If set to true, the contet of sent mails is saved to the database.
+     */
+    'store_content' => env('SENDS_STORE_CONTENT', false),
+
     'headers' => [
         /**
          * Header containing the encrypted FQN of the mailable class.
@@ -243,6 +248,21 @@ protected $listen = [
 ```
 
 (If you want to store the value of `Message-ID` in your database, do not add the event listener but update the `SENDS_HEADERS_SEND_UUID`-env variable to `Message-ID`. The `StoreOutgoingMailListener` will then store the `Message-ID` in the database.)
+
+### Store Content of Mails
+By default, the package does not store the content of sent out emails.
+By default, the package does not store the content of sent out emails. By setting the `sends.store_content` configuration value to `true`, the body of all outgoing mails is stored in the `content`-column in the `sends` database table. 
+
+```php
+/**
+ * If set to true, the contet of sent mails is saved to the database.
+ */
+'store_content' => true,
+```
+
+```shell
+SENDS_STORE_CONTENT=true
+``` 
 
 ### Prune Send Models
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ return [
     'send_model' => \Wnx\Sends\Models\Send::class,
 
     /**
-     * If set to true, the contet of sent mails is saved to the database.
+     * If set to true, the content of sent mails is saved to the database.
      */
     'store_content' => env('SENDS_STORE_CONTENT', false),
 

--- a/config/sends.php
+++ b/config/sends.php
@@ -6,6 +6,11 @@ return [
      */
     'send_model' => \Wnx\Sends\Models\Send::class,
 
+    /**
+     * If set to true, the contet of sent mails is saved to the database.
+     */
+    'store_content' => env('SENDS_STORE_CONTENT', false),
+
     'headers' => [
         /**
          * Header containing the encrypted FQN of the mailable class.

--- a/config/sends.php
+++ b/config/sends.php
@@ -7,7 +7,7 @@ return [
     'send_model' => \Wnx\Sends\Models\Send::class,
 
     /**
-     * If set to true, the contet of sent mails is saved to the database.
+     * If set to true, the content of sent mails is saved to the database.
      */
     'store_content' => env('SENDS_STORE_CONTENT', false),
 

--- a/database/migrations/create_sends_table.php.stub
+++ b/database/migrations/create_sends_table.php.stub
@@ -13,6 +13,7 @@ return new class extends Migration
             $table->string('uuid')->nullable()->index();
             $table->string('mail_class')->nullable()->index();
             $table->string('subject')->nullable();
+            $table->text('content')->nullable();
             $table->json('from')->nullable();
             $table->json('reply_to')->nullable();
             $table->json('to')->nullable();

--- a/src/Listeners/StoreOutgoingMailListener.php
+++ b/src/Listeners/StoreOutgoingMailListener.php
@@ -39,7 +39,7 @@ class StoreOutgoingMailListener
         ]);
     }
 
-    private function getSendUuid(MessageSent $event): ?string
+    protected function getSendUuid(MessageSent $event): ?string
     {
         if (! $event->message->getHeaders()->has(config('sends.headers.send_uuid'))) {
             return null;
@@ -54,7 +54,7 @@ class StoreOutgoingMailListener
         return $headerValue->getFieldBody();
     }
 
-    private function getMailClassHeaderValue(MessageSent $event): ?string
+    protected function getMailClassHeaderValue(MessageSent $event): ?string
     {
         if (! $event->message->getHeaders()->has(config('sends.headers.mail_class'))) {
             return null;
@@ -72,7 +72,7 @@ class StoreOutgoingMailListener
     /**
      * @throws \JsonException
      */
-    private function attachModelsToSendModel(MessageSent $event, Send $send): void
+    protected function attachModelsToSendModel(MessageSent $event, Send $send): void
     {
         $this->getModels($event)
             ->each(fn (HasSends $model) => $model->sends()->attach($send));
@@ -81,7 +81,7 @@ class StoreOutgoingMailListener
     /**
      * @throws \JsonException
      */
-    private function getModels(MessageSent $event): Collection
+    protected function getModels(MessageSent $event): Collection
     {
         if (! $event->message->getHeaders()->has(config('sends.headers.models'))) {
             return collect([]);
@@ -105,7 +105,7 @@ class StoreOutgoingMailListener
             ->filter(fn (Model $model) => (new ReflectionClass($model))->implementsInterface(HasSends::class));
     }
 
-    private function getContent(MessageSent $event): ?string
+    protected function getContent(MessageSent $event): ?string
     {
         if (config('sends.store_content', false) === false) {
             return null;

--- a/src/Listeners/StoreOutgoingMailListener.php
+++ b/src/Listeners/StoreOutgoingMailListener.php
@@ -29,6 +29,7 @@ class StoreOutgoingMailListener
             'uuid' => $this->getSendUuid($event),
             'mail_class' => $this->getMailClassHeaderValue($event),
             'subject' => $event->message->getSubject(),
+            'content' => $this->getContent($event),
             'from' => $event->message->getFrom(),
             'reply_to' => $event->message->getReplyTo(),
             'to' => $event->message->getTo(),
@@ -102,5 +103,14 @@ class StoreOutgoingMailListener
                 return $model::find($id);
             })
             ->filter(fn (Model $model) => (new ReflectionClass($model))->implementsInterface(HasSends::class));
+    }
+
+    private function getContent(MessageSent $event): ?string
+    {
+        if (config('sends.store_content', false) === false) {
+            return null;
+        }
+
+        return $event->message->getBody();
     }
 }

--- a/src/Models/Send.php
+++ b/src/Models/Send.php
@@ -14,6 +14,7 @@ use Wnx\Sends\Database\Factories\SendFactory;
  * @property-read string $uuid
  * @property-read string $mail_class
  * @property-read string $subject
+ * @property-read ?string $content
  * @property-read array $from
  * @property-read array $reply_to
  * @property-read array $to
@@ -40,6 +41,7 @@ class Send extends Model
         'uuid',
         'mail_class',
         'subject',
+        'content',
         'from',
         'reply_to',
         'to',

--- a/tests/Listeners/StoreOutgoingMailListenerTest.php
+++ b/tests/Listeners/StoreOutgoingMailListenerTest.php
@@ -222,3 +222,29 @@ it('stores outgoing notifications in database table', function () {
         ['sent_at', '!=', null],
     ]);
 });
+
+it('does not store content of outgoing mail in database table if config is set to false', function () {
+    config(['sends.store_content' => false]);
+
+    Mail::to('test@example.com')
+        ->send(new TestMail());
+
+    assertDatabaseHas('sends', [
+        'content' => null,
+    ]);
+
+    assertDatabaseCount('sendables', 0);
+});
+
+it('stores content of outgoing mail in database table if config is set to true', function () {
+    config(['sends.store_content' => true]);
+
+    Mail::to('test@example.com')
+        ->send(new TestMail());
+
+    assertDatabaseHas('sends', [
+        'content' => "<h1>Test</h1>\n\n<p>This is a test mail.</p>\n",
+    ]);
+
+    assertDatabaseCount('sendables', 0);
+});

--- a/tests/TestSupport/resources/views/emails/test.blade.php
+++ b/tests/TestSupport/resources/views/emails/test.blade.php
@@ -1,1 +1,3 @@
-This is a test mail.
+<h1>Test</h1>
+
+<p>This is a test mail.</p>


### PR DESCRIPTION
[On Twitter](https://twitter.com/pavlentij/status/1476151721021915143) the question came up, why the package doesn't store the content/body of outgoging mails. 
I honestly didn't think about that at all, as my primary usecase for the packge is to keep track of meta data.

Implementing this feature is trivial, as the `Swif_Message` instance exposes a `getBody()` method.

The feature is hidden behind a new configuration flag (`sends.store_content`) and has to be enabled by the consumer of the package. I will keep it that way in future releases, as I would like to prevent users from shooting themself in the foot. Storing the body of outgoing mails can blow up the size of a database pretty quickly.

## Questions to clarify

- [x] Should I create an additional migration to add the `content`-column? Or should this be the concern of the consumer? (Like done in [the UPGRADE guide](https://github.com/stefanzweifel/laravel-sends/blob/main/UPGRADING.md#from-v01-to-v10) for v0 to v1) → Will make this a new major version. The package is too young to already add multiple migrations to it. Will provide instructions in the upgrade guide

