### PR TITLE
Usage of custom model

### DIFF
--- a/src/Support/HasSendsTrait.php
+++ b/src/Support/HasSendsTrait.php
@@ -12,7 +12,7 @@ trait HasSendsTrait
     public function sends(): MorphToMany
     {
         return $this
-            ->morphToMany(Send::class, 'sendable')
+            ->morphToMany( config('sends.send_model'), 'sendable','sendables','sendable_id','send_id')
             ->orderByDesc('id');
     }
 }

--- a/src/Support/HasSendsTrait.php
+++ b/src/Support/HasSendsTrait.php
@@ -12,7 +12,6 @@ trait HasSendsTrait
     public function sends(): MorphToMany
     {
         return $this
-            ->morphToMany( config('sends.send_model'), 'sendable','sendables','sendable_id','send_id')
-            ->orderByDesc('id');
+            ->morphToMany( config('sends.send_model'), 'sendable','sendables','sendable_id','send_id');
     }
 }

--- a/src/Support/StoreMailables.php
+++ b/src/Support/StoreMailables.php
@@ -42,7 +42,7 @@ trait StoreMailables
             ->unique()
             ->map(fn (HasSends $model) => [
                 'model' => get_class($model),
-                'id' => $model->id,
+                'id' => $model->getKey(),
             ])
             ->toJson();
 


### PR DESCRIPTION
When using a custom model (extending the default one). This package automatically uses `id` as column name. Except not everyone uses the default laravel naming conventions.