### PR TITLE
Add Support for Laravel 9 / Drop Support for Laravel 8

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,10 +1,6 @@
 name: run-tests
 
-on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+on: [push, pull_request]
 
 jobs:
   test:
@@ -13,37 +9,32 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.0, 8.1]
-        laravel: [8.*, 9.*]
-        stability: [prefer-lowest, prefer-stable]
+        php: [8.1, 8.0]
+        laravel: [9.*, 8.*]
+        dependency-version: [prefer-stable]
         include:
-          - laravel: 9.*
-            testbench: 7.*
-          - laravel: 8.*
-            testbench: ^6.6
+          -   laravel: 9.*
+              testbench: 7.*
+          -   laravel: 8.*
+              testbench: ^6.6
 
-    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
+    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
+      -   name: Checkout code
+          uses: actions/checkout@v2
 
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
-          coverage: pcov
+      -   name: Setup PHP
+          uses: shivammathur/setup-php@v2
+          with:
+            php-version: ${{ matrix.php }}
+            extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
+            coverage: pcov
 
-      - name: Setup problem matchers
-        run: |
-          echo "::add-matcher::${{ runner.tool_cache }}/php.json"
-          echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+      -   name: Install dependencies
+          run: |
+            composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+            composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
 
-      - name: Install dependencies
-        run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
-          composer update --${{ matrix.stability }} --prefer-dist --no-interaction
-
-      - name: Execute tests
-        run: vendor/bin/pest --coverage
+      -   name: Execute tests
+          run: vendor/bin/pest --coverage

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,9 +14,11 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         php: [8.0, 8.1]
-        laravel: [8.*]
+        laravel: [8.*, 9.*]
         stability: [prefer-lowest, prefer-stable]
         include:
+          - laravel: 9.*
+            testbench: 7.*
           - laravel: 8.*
             testbench: ^6.6
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,13 +10,11 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         php: [8.1, 8.0]
-        laravel: [9.*, 8.*]
+        laravel: [9.*]
         dependency-version: [prefer-stable]
         include:
           -   laravel: 9.*
               testbench: 7.*
-          -   laravel: 8.*
-              testbench: ^6.6
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -19,13 +19,13 @@
     "require": {
         "php": "^8.0",
         "spatie/laravel-package-tools": "^1.9.2",
-        "illuminate/contracts": "^8.73"
+        "illuminate/contracts": "^8.73|^9.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.3",
         "nunomaduro/collision": "^5.10",
         "nunomaduro/larastan": "^1.0",
-        "orchestra/testbench": "^6.22",
+        "orchestra/testbench": "^6.22|^7",
         "pestphp/pest": "^1.21",
         "pestphp/pest-plugin-laravel": "^1.1",
         "phpstan/extension-installer": "^1.1",

--- a/composer.json
+++ b/composer.json
@@ -19,13 +19,13 @@
     "require": {
         "php": "^8.0",
         "spatie/laravel-package-tools": "^1.9.2",
-        "illuminate/contracts": "^8.73|^9.0"
+        "illuminate/contracts": "^9.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.4",
         "nunomaduro/collision": "^5.10 |^6.0",
         "nunomaduro/larastan": "^1.0",
-        "orchestra/testbench": "^6.22|^7",
+        "orchestra/testbench": "^7",
         "pestphp/pest": "^1.21",
         "pestphp/pest-plugin-laravel": "^1.1",
         "phpstan/extension-installer": "^1.1",

--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,8 @@
         "illuminate/contracts": "^8.73|^9.0"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.3",
-        "nunomaduro/collision": "^5.10",
+        "friendsofphp/php-cs-fixer": "^3.4",
+        "nunomaduro/collision": "^5.10 |^6.0",
         "nunomaduro/larastan": "^1.0",
         "orchestra/testbench": "^6.22|^7",
         "pestphp/pest": "^1.21",

--- a/src/Listeners/StoreOutgoingMailListener.php
+++ b/src/Listeners/StoreOutgoingMailListener.php
@@ -122,8 +122,6 @@ class StoreOutgoingMailListener
     private function getArrayFromAddress(array $address): Collection
     {
         return collect($address)
-            ->map(function (Address $address) {
-                return [$address->getAddress() => $address->getName()];
-            });
+            ->flatMap(fn(Address $address) => [$address->getAddress() => $address->getName()]);
     }
 }

--- a/src/Listeners/StoreOutgoingMailListener.php
+++ b/src/Listeners/StoreOutgoingMailListener.php
@@ -35,7 +35,7 @@ class StoreOutgoingMailListener
             'reply_to' => $this->getAddressesValue($event->message->getReplyTo()),
             'to' => $this->getAddressesValue($event->message->getTo()),
             'cc' => $this->getAddressesValue($event->message->getCc()),
-            'bcc' =>$this->getAddressesValue($event->message->getBcc()),
+            'bcc' => $this->getAddressesValue($event->message->getBcc()),
             'sent_at' => now(),
         ]);
     }
@@ -122,7 +122,7 @@ class StoreOutgoingMailListener
     private function getAddressesValue(array $address): ?Collection
     {
         $addresses = collect($address)
-            ->flatMap(fn(Address $address) => [$address->getAddress() => $address->getName()]);
+            ->flatMap(fn (Address $address) => [$address->getAddress() => $address->getName()]);
 
         return $addresses->count() > 0 ? $addresses : null;
     }

--- a/src/Listeners/StoreOutgoingMailListener.php
+++ b/src/Listeners/StoreOutgoingMailListener.php
@@ -122,7 +122,7 @@ class StoreOutgoingMailListener
     private function getAddressesValue(array $address): ?Collection
     {
         $addresses = collect($address)
-            ->flatMap(fn (Address $address) => [$address->getAddress() => $address->getName()]);
+            ->flatMap(fn (Address $address) => [$address->getAddress() => $address->getName() === '' ? null : $address->getName()]);
 
         return $addresses->count() > 0 ? $addresses : null;
     }

--- a/src/Listeners/StoreOutgoingMailListener.php
+++ b/src/Listeners/StoreOutgoingMailListener.php
@@ -31,11 +31,11 @@ class StoreOutgoingMailListener
             'mail_class' => $this->getMailClassHeaderValue($event),
             'subject' => $event->message->getSubject(),
             'content' => $this->getContent($event),
-            'from' => $this->getArrayFromAddress($event->message->getFrom()),
-            'reply_to' => $this->getArrayFromAddress($event->message->getReplyTo()),
-            'to' => $this->getArrayFromAddress($event->message->getTo()),
-            'cc' => $this->getArrayFromAddress($event->message->getCc()),
-            'bcc' =>$this->getArrayFromAddress($event->message->getBcc()),
+            'from' => $this->getAddressesValue($event->message->getFrom()),
+            'reply_to' => $this->getAddressesValue($event->message->getReplyTo()),
+            'to' => $this->getAddressesValue($event->message->getTo()),
+            'cc' => $this->getAddressesValue($event->message->getCc()),
+            'bcc' =>$this->getAddressesValue($event->message->getBcc()),
             'sent_at' => now(),
         ]);
     }
@@ -117,11 +117,13 @@ class StoreOutgoingMailListener
 
     /**
      * @param array<Address> $address
-     * @return Collection
+     * @return Collection|null
      */
-    private function getArrayFromAddress(array $address): Collection
+    private function getAddressesValue(array $address): ?Collection
     {
-        return collect($address)
+        $addresses = collect($address)
             ->flatMap(fn(Address $address) => [$address->getAddress() => $address->getName()]);
+
+        return $addresses->count() > 0 ? $addresses : null;
     }
 }

--- a/src/Support/StoreMailables.php
+++ b/src/Support/StoreMailables.php
@@ -15,7 +15,7 @@ trait StoreMailables
 {
     protected function storeClassName(): self
     {
-        $this->withSwiftMessage(function (Swift_Message|Email $message) {
+        $this->withSymfonyMessage(function (Email $message) {
             $message->getHeaders()->addTextHeader(config('sends.headers.mail_class'), encrypt(self::class));
         });
 
@@ -47,7 +47,7 @@ trait StoreMailables
             ])
             ->toJson();
 
-        $this->withSwiftMessage(function (Swift_Message|Email $message) use ($models) {
+        $this->withSymfonyMessage(function (Email $message) use ($models) {
             $message->getHeaders()->addTextHeader(config('sends.headers.models'), encrypt($models));
         });
 

--- a/src/Support/StoreMailables.php
+++ b/src/Support/StoreMailables.php
@@ -7,7 +7,6 @@ namespace Wnx\Sends\Support;
 use Illuminate\Support\Collection;
 use ReflectionClass;
 use ReflectionProperty;
-use Swift_Message;
 use Symfony\Component\Mime\Email;
 use Wnx\Sends\Contracts\HasSends;
 

--- a/src/Support/StoreMailables.php
+++ b/src/Support/StoreMailables.php
@@ -8,13 +8,14 @@ use Illuminate\Support\Collection;
 use ReflectionClass;
 use ReflectionProperty;
 use Swift_Message;
+use Symfony\Component\Mime\Email;
 use Wnx\Sends\Contracts\HasSends;
 
 trait StoreMailables
 {
     protected function storeClassName(): self
     {
-        $this->withSwiftMessage(function (Swift_Message $message) {
+        $this->withSwiftMessage(function (Swift_Message|Email $message) {
             $message->getHeaders()->addTextHeader(config('sends.headers.mail_class'), encrypt(self::class));
         });
 
@@ -46,7 +47,7 @@ trait StoreMailables
             ])
             ->toJson();
 
-        $this->withSwiftMessage(function (Swift_Message $message) use ($models) {
+        $this->withSwiftMessage(function (Swift_Message|Email $message) use ($models) {
             $message->getHeaders()->addTextHeader(config('sends.headers.models'), encrypt($models));
         });
 

--- a/tests/Listeners/AttachSendUuidListenerTest.php
+++ b/tests/Listeners/AttachSendUuidListenerTest.php
@@ -3,13 +3,12 @@
 declare(strict_types=1);
 
 use Illuminate\Mail\Events\MessageSending;
-use Symfony\Component\Mime\Email;
 use function PHPUnit\Framework\assertNotNull;
 use function PHPUnit\Framework\assertTrue;
+use Symfony\Component\Mime\Email;
 use Wnx\Sends\Listeners\AttachSendUuidListener;
 
 it('attaches send uuid header', function () {
-
     $event = new MessageSending(new Email());
 
     // $event = new MessageSending(new Swift_Message());

--- a/tests/Listeners/AttachSendUuidListenerTest.php
+++ b/tests/Listeners/AttachSendUuidListenerTest.php
@@ -3,12 +3,16 @@
 declare(strict_types=1);
 
 use Illuminate\Mail\Events\MessageSending;
+use Symfony\Component\Mime\Email;
 use function PHPUnit\Framework\assertNotNull;
 use function PHPUnit\Framework\assertTrue;
 use Wnx\Sends\Listeners\AttachSendUuidListener;
 
 it('attaches send uuid header', function () {
-    $event = new MessageSending(new Swift_Message());
+
+    $event = new MessageSending(new Email());
+
+    // $event = new MessageSending(new Swift_Message());
 
     (new AttachSendUuidListener())->handle($event);
 

--- a/tests/Listeners/AttachSendUuidListenerTest.php
+++ b/tests/Listeners/AttachSendUuidListenerTest.php
@@ -11,8 +11,6 @@ use Wnx\Sends\Listeners\AttachSendUuidListener;
 it('attaches send uuid header', function () {
     $event = new MessageSending(new Email());
 
-    // $event = new MessageSending(new Swift_Message());
-
     (new AttachSendUuidListener())->handle($event);
 
     assertTrue($event->message->getHeaders()->has('X-Laravel-Send-UUID'));

--- a/tests/Listeners/StoreOutgoingMailListenerTest.php
+++ b/tests/Listeners/StoreOutgoingMailListenerTest.php
@@ -24,8 +24,8 @@ it('stores outgoing mails in database table', function () {
         [
             'email' => 'to-1@example.com',
             'name' => 'To 1 Name',
+        ],
         'to-2@example.com',
-
     ])
         ->send(new TestMail());
 

--- a/tests/Listeners/StoreOutgoingMailListenerTest.php
+++ b/tests/Listeners/StoreOutgoingMailListenerTest.php
@@ -19,11 +19,14 @@ use Wnx\Sends\Tests\TestSupport\Models\TestModel;
 use Wnx\Sends\Tests\TestSupport\Models\TestModelWithoutHasSendsContract;
 use Wnx\Sends\Tests\TestSupport\Notifications\TestNotification;
 
-it('stores_outgoing_mails_in_database_table', function () {
+it('stores outgoing mails in database table', function () {
     Mail::to([
         [
-            'email' => 'test@example.com',
-            'name' => 'To Name',
+            'email' => 'to-1@example.com',
+            'name' => 'To 1 Name',
+        ], [
+            'email' => 'to-2@example.com',
+            'name' => 'To 2 Name',
         ],
     ])
         ->send(new TestMail());
@@ -32,9 +35,12 @@ it('stores_outgoing_mails_in_database_table', function () {
         'uuid' => null,
         'mail_class' => null,
         'subject' => '::subject::',
-        'to' => json_encode(['test@example.com' => 'To Name']),
-        'cc' => null,
-        'bcc' => null,
+        'to' => json_encode([
+            'to-1@example.com' => 'To 1 Name',
+            'to-2@example.com' => 'To 2 Name',
+        ]),
+        'cc' => json_encode([]),
+        'bcc' =>  json_encode([]),
         ['sent_at', '!=', null],
     ]);
 
@@ -64,13 +70,13 @@ it('stores to cc and bcc addresses in database table', function () {
         'subject' => '::subject::',
         'from' => json_encode(['from@example.com' => 'From']),
         'reply_to' => json_encode(['reply@example.com' => 'Reply']),
-        'to' => json_encode(['test@example.com' => null]),
+        'to' => json_encode(['test@example.com' => '']),
         'cc' => json_encode([
-            'cc-1@example.com' => null,
+            'cc-1@example.com' => '',
             'cc-2@example.com' => 'CC Name 2',
         ]),
         'bcc' => json_encode([
-            'bcc-1@example.com' => null,
+            'bcc-1@example.com' => '',
             'bcc-2@example.com' => 'BCC Name 2',
         ]),
         ['sent_at', '!=', null],
@@ -97,9 +103,6 @@ it('stores fqn of mail class in database table', function () {
     assertDatabaseHas('sends', [
         'mail_class' => TestMailWithMailClassHeader::class,
         'subject' => '::subject::',
-        'to' => json_encode(['test@example.com' => null]),
-        'cc' => null,
-        'bcc' => null,
         ['sent_at', '!=', null],
     ]);
 });
@@ -113,9 +116,6 @@ it('attaches related models to a send model if respective header is present', fu
     assertDatabaseHas('sends', [
         'mail_class' => null,
         'subject' => '::subject::',
-        'to' => json_encode(['test@example.com' => null]),
-        'cc' => null,
-        'bcc' => null,
         ['sent_at', '!=', null],
     ]);
     assertDatabaseHas('sendables', [
@@ -135,9 +135,6 @@ it('attaches related models to a send model by passing arguments to associateWit
     assertDatabaseHas('sends', [
         'mail_class' => null,
         'subject' => '::subject::',
-        'to' => json_encode(['test@example.com' => null]),
-        'cc' => null,
-        'bcc' => null,
         ['sent_at', '!=', null],
     ]);
     assertDatabaseHas('sendables', [
@@ -161,9 +158,6 @@ it('attaches related models to a send model based on the public properties of th
     assertDatabaseHas('sends', [
         'mail_class' => null,
         'subject' => '::subject::',
-        'to' => json_encode(['test@example.com' => null]),
-        'cc' => null,
-        'bcc' => null,
         ['sent_at', '!=', null],
     ]);
     assertDatabaseHas('sendables', [
@@ -182,9 +176,6 @@ it('attaches related models only once if related models are defined both as publ
     assertDatabaseHas('sends', [
         'mail_class' => null,
         'subject' => '::subject::',
-        'to' => json_encode(['test@example.com' => null]),
-        'cc' => null,
-        'bcc' => null,
         ['sent_at', '!=', null],
     ]);
     assertDatabaseCount('sendables', 1);
@@ -221,9 +212,7 @@ it('stores outgoing notifications in database table', function () {
         'uuid' => null,
         'mail_class' => null,
         'subject' => '::subject-of-notification::',
-        'to' => json_encode(['foo@example.com' => null]),
-        'cc' => null,
-        'bcc' => null,
+        'to' => json_encode(['foo@example.com' => '']),
         ['sent_at', '!=', null],
     ]);
 });

--- a/tests/Listeners/StoreOutgoingMailListenerTest.php
+++ b/tests/Listeners/StoreOutgoingMailListenerTest.php
@@ -19,15 +19,20 @@ use Wnx\Sends\Tests\TestSupport\Models\TestModel;
 use Wnx\Sends\Tests\TestSupport\Models\TestModelWithoutHasSendsContract;
 use Wnx\Sends\Tests\TestSupport\Notifications\TestNotification;
 
-it('stores outgoing mails in database table', function () {
-    Mail::to('test@example.com')
+it('stores_outgoing_mails_in_database_table', function () {
+    Mail::to([
+        [
+            'email' => 'test@example.com',
+            'name' => 'To Name',
+        ],
+    ])
         ->send(new TestMail());
 
     assertDatabaseHas('sends', [
         'uuid' => null,
         'mail_class' => null,
         'subject' => '::subject::',
-        'to' => json_encode(['test@example.com' => null]),
+        'to' => json_encode(['test@example.com' => 'To Name']),
         'cc' => null,
         'bcc' => null,
         ['sent_at', '!=', null],

--- a/tests/Listeners/StoreOutgoingMailListenerTest.php
+++ b/tests/Listeners/StoreOutgoingMailListenerTest.php
@@ -101,6 +101,9 @@ it('stores fqn of mail class in database table', function () {
     assertDatabaseHas('sends', [
         'mail_class' => TestMailWithMailClassHeader::class,
         'subject' => '::subject::',
+        'to' => json_encode(['test@example.com' => null]),
+        'cc' => null,
+        'bcc' => null,
         ['sent_at', '!=', null],
     ]);
 });
@@ -133,6 +136,9 @@ it('attaches related models to a send model by passing arguments to associateWit
     assertDatabaseHas('sends', [
         'mail_class' => null,
         'subject' => '::subject::',
+        'to' => json_encode(['test@example.com' => null]),
+        'cc' => null,
+        'bcc' => null,
         ['sent_at', '!=', null],
     ]);
     assertDatabaseHas('sendables', [
@@ -156,6 +162,9 @@ it('attaches related models to a send model based on the public properties of th
     assertDatabaseHas('sends', [
         'mail_class' => null,
         'subject' => '::subject::',
+        'to' => json_encode(['test@example.com' => null]),
+        'cc' => null,
+        'bcc' => null,
         ['sent_at', '!=', null],
     ]);
     assertDatabaseHas('sendables', [
@@ -174,6 +183,9 @@ it('attaches related models only once if related models are defined both as publ
     assertDatabaseHas('sends', [
         'mail_class' => null,
         'subject' => '::subject::',
+        'to' => json_encode(['test@example.com' => null]),
+        'cc' => null,
+        'bcc' => null,
         ['sent_at', '!=', null],
     ]);
     assertDatabaseCount('sendables', 1);
@@ -211,6 +223,8 @@ it('stores outgoing notifications in database table', function () {
         'mail_class' => null,
         'subject' => '::subject-of-notification::',
         'to' => json_encode(['foo@example.com' => null]),
+        'cc' => null,
+        'bcc' => null,
         ['sent_at', '!=', null],
     ]);
 });

--- a/tests/Listeners/StoreOutgoingMailListenerTest.php
+++ b/tests/Listeners/StoreOutgoingMailListenerTest.php
@@ -117,6 +117,9 @@ it('attaches related models to a send model if respective header is present', fu
     assertDatabaseHas('sends', [
         'mail_class' => null,
         'subject' => '::subject::',
+        'to' => json_encode(['test@example.com' => null]),
+        'cc' => null,
+        'bcc' => null,
         ['sent_at', '!=', null],
     ]);
     assertDatabaseHas('sendables', [

--- a/tests/Listeners/StoreOutgoingMailListenerTest.php
+++ b/tests/Listeners/StoreOutgoingMailListenerTest.php
@@ -39,8 +39,8 @@ it('stores outgoing mails in database table', function () {
             'to-1@example.com' => 'To 1 Name',
             'to-2@example.com' => 'To 2 Name',
         ]),
-        'cc' => json_encode([]),
-        'bcc' =>  json_encode([]),
+        'cc' => null,
+        'bcc' =>  null,
         ['sent_at', '!=', null],
     ]);
 

--- a/tests/Listeners/StoreOutgoingMailListenerTest.php
+++ b/tests/Listeners/StoreOutgoingMailListenerTest.php
@@ -40,7 +40,7 @@ it('stores outgoing mails in database table', function () {
             'to-2@example.com' => 'To 2 Name',
         ]),
         'cc' => null,
-        'bcc' =>  null,
+        'bcc' => null,
         ['sent_at', '!=', null],
     ]);
 

--- a/tests/Listeners/StoreOutgoingMailListenerTest.php
+++ b/tests/Listeners/StoreOutgoingMailListenerTest.php
@@ -24,10 +24,8 @@ it('stores outgoing mails in database table', function () {
         [
             'email' => 'to-1@example.com',
             'name' => 'To 1 Name',
-        ], [
-            'email' => 'to-2@example.com',
-            'name' => 'To 2 Name',
         ],
+        'to-2@example.com',
     ])
         ->send(new TestMail());
 
@@ -37,7 +35,7 @@ it('stores outgoing mails in database table', function () {
         'subject' => '::subject::',
         'to' => json_encode([
             'to-1@example.com' => 'To 1 Name',
-            'to-2@example.com' => 'To 2 Name',
+            'to-2@example.com' => null,
         ]),
         'cc' => null,
         'bcc' => null,
@@ -70,13 +68,13 @@ it('stores to cc and bcc addresses in database table', function () {
         'subject' => '::subject::',
         'from' => json_encode(['from@example.com' => 'From']),
         'reply_to' => json_encode(['reply@example.com' => 'Reply']),
-        'to' => json_encode(['test@example.com' => '']),
+        'to' => json_encode(['test@example.com' => null]),
         'cc' => json_encode([
-            'cc-1@example.com' => '',
+            'cc-1@example.com' => null,
             'cc-2@example.com' => 'CC Name 2',
         ]),
         'bcc' => json_encode([
-            'bcc-1@example.com' => '',
+            'bcc-1@example.com' => null,
             'bcc-2@example.com' => 'BCC Name 2',
         ]),
         ['sent_at', '!=', null],
@@ -212,7 +210,7 @@ it('stores outgoing notifications in database table', function () {
         'uuid' => null,
         'mail_class' => null,
         'subject' => '::subject-of-notification::',
-        'to' => json_encode(['foo@example.com' => '']),
+        'to' => json_encode(['foo@example.com' => null]),
         ['sent_at', '!=', null],
     ]);
 });


### PR DESCRIPTION
Add Support for Laravel 9.

Also drop support for Laravel 8, as Laravel internally now uses `symfony/mailer` instead of `Swift_Mailer`.