### PR TITLE
Remove SendFactory ReturnType Hint

### DIFF
--- a/src/Models/Send.php
+++ b/src/Models/Send.php
@@ -78,7 +78,7 @@ class Send extends Model
         'rejected_at' => 'immutable_datetime',
     ];
 
-    protected static function newFactory(): SendFactory
+    protected static function newFactory()
     {
         return new SendFactory();
     }


### PR DESCRIPTION
Allows consumers of the project to use their own `Send`-factory for their custom `Send`-model