### PR TITLE
Change getMailClassHeader return value from self to static

### DIFF
--- a/src/Support/StoreMailables.php
+++ b/src/Support/StoreMailables.php
@@ -29,7 +29,7 @@ trait StoreMailables
     {
         return new Header(
             name: config('sends.headers.mail_class'),
-            value: encrypt(self::class)
+            value: encrypt(static::class)
         );
     }
 


### PR DESCRIPTION
If you create an abstract class to clean up all your Mailable classes that extends from it, the value stored in sends table is the abstract class and not the mailable class. 

Changing the value from self to static in getMailClassHeader method improves this behavior.